### PR TITLE
deprecate electron-prebuilt after it is published

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,9 @@ app.post('/', function (req, res) {
             if (semver.gt(lastVersion, newVersion)) {
               const execSync = require('child_process').execSync
               execSync(`${__dirname}/node_modules/.bin/npm dist-tags add ${packageName}@${lastVersion} latest`)
+              if (packageName === 'electron-prebuilt') {
+                execSync(`${__dirname}/node_modules/.bin/npm deprecate electron-prebuilt@">=1.3.1" "electron-prebuilt has been renamed to electron. For more details, see http://electron.atom.io/blog/2016/08/16/npm-install-electron"`)
+              }
             }
           })
         })


### PR DESCRIPTION
I realized today that any time a new version of `electron-prebuilt` is published, users running `npm install electron-prebuilt` will no longer see a deprecation message, because that new version is not deprecated.

This updates the service to run `npm deprecate` immediately after publishing a new version.

cc @electron/maintainers 
