### PR TITLE
Publish prereleases under beta tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,8 @@ app.post('/', function (req, res) {
         repo: repo,
         tag_name: `v${newVersion}`,
         name: `v${newVersion}`,
-        body: `[${newVersion} Release Notes](https://github.com/electron/electron/releases/v${newVersion})`
+        body: `[${newVersion} Release Notes](https://github.com/electron/electron/releases/v${newVersion})`,
+        prerelease: prerelease
       })
       .catch(function (err) {
         console.error('Failed to create release')
@@ -113,7 +114,9 @@ app.post('/', function (req, res) {
       })
     })
     .then(function (release) {
-      npm.load({}, function (err) {
+      var npmConfig = {}
+      if (prerelease) npmConfig.tag = 'beta'
+      npm.load(npmConfig, function (err) {
         if (err) {
           console.error('Failed to load npm')
           throw err
@@ -129,14 +132,7 @@ app.post('/', function (req, res) {
         .then(function (response) {
           const info = response[0]
           const lastVersion = info[Object.keys(info)[0]]['dist-tags'].latest
-          const publishArgs = [release.tarball_url]
-
-          // Use beta tag for prereleases
-          if (prerelease) {
-            publishArgs.push('--tag', 'beta')
-          }
-
-          return publishAsync(publishArgs)
+          return publishAsync([release.tarball_url])
           .catch(function (err) {
             console.error('Failed to publish package')
             throw err

--- a/index.js
+++ b/index.js
@@ -43,7 +43,12 @@ app.post('/', function (req, res) {
     let getContentAsync = Promise.promisify(github.repos.getContent)
     let updateFileAsync = Promise.promisify(github.repos.updateFile)
     let newVersion = req.body.release.tag_name.replace('v', '')
+    let draft = req.body.release.draft
     let npmrc = path.resolve(process.env.HOME, '.npmrc')
+
+    if (draft) {
+      return res.status(403).send('This service ignores draft releases')
+    }
 
     github.authenticate({ type: 'oauth', token: token })
     getContentAsync({

--- a/index.js
+++ b/index.js
@@ -103,8 +103,8 @@ app.post('/', function (req, res) {
       return createReleaseAsync({
         owner: owner,
         repo: repo,
-        tag_name: `v${newVersion}`,
-        name: `v${newVersion}`,
+        tag_name: req.body.release.tag_name,
+        name: req.body.release.name,
         body: `[${newVersion} Release Notes](https://github.com/electron/electron/releases/v${newVersion})`,
         prerelease: prerelease
       })


### PR DESCRIPTION
If a prerelease release is published then publish it under the `beta` tag instead of `latest.